### PR TITLE
日記一覧にページネーション導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "bootsnap", require: false
 
 gem 'faker'
 
+gem 'kaminari', '1.2.2'
+gem 'bootstrap5-kaminari-views'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     brakeman (6.2.1)
       racc
     builder (3.3.0)
@@ -155,6 +158,18 @@ GEM
     json (2.7.2)
     jwt (2.8.2)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.22.0)
@@ -369,6 +384,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bootstrap5-kaminari-views
   brakeman
   capybara
   carrierwave (= 2.2.2)
@@ -378,6 +394,7 @@ DEPENDENCIES
   faker
   jbuilder
   jsbundling-rails
+  kaminari (= 1.2.2)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,6 +1,6 @@
 class DiariesController < ApplicationController
   def index
-    @diaries = Diary.includes(:user)
+    @diaries = Diary.includes(:user).page(params[:page])
   end
 
   def new

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -19,6 +19,7 @@
           <div class="mb-3">日記がありません</div>
         <% end %>
       </div>
+      <%= paginate @diaries, theme: 'bootstrap-5' %>
     </div>
   </div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+end


### PR DESCRIPTION
日記一覧におページネーションを導入しました。

詳細：１ページ２０個表示する仕様となり、２１個目の日記は次のページに表示される様になる。